### PR TITLE
Add ChatMessageResign Command

### DIFF
--- a/catalog/archetypes/Commands/ChatMessageResign.json
+++ b/catalog/archetypes/Commands/ChatMessageResign.json
@@ -1,0 +1,226 @@
+{
+  "actions": [
+    {
+      "function_id": "Game_EndGameForPlayer",
+      "parameters": [
+        {
+          "id": "player",
+          "expressions": [
+            {
+              "function": {
+                "function_id": "Player_GetTriggeringPlayer"
+              },
+              "type": "Function"
+            }
+          ]
+        },
+        {
+          "id": "outcome",
+          "expressions": [
+            {
+              "type": "Preset",
+              "preset": {
+                "preset_id": "Game_GameOverType",
+                "value_id": "defeat"
+              }
+            }
+          ]
+        },
+        {
+          "id": "kick",
+          "expressions": [
+            {
+              "type": "Preset",
+              "preset": {
+                "preset_id": "Game_KickDontKick",
+                "value_id": "nokick"
+              }
+            }
+          ]
+        }
+      ]
+    },    {
+      "function_id": "UnitGroup_ForEachUnitInGroup",
+      "is_enabled": true,
+      "parameters": [
+        {
+          "expressions": [
+            {
+              "type": "Function",
+              "function": {
+                "function_id": "UnitGroup_GetUnitsOfPlayer"
+              }
+            }
+          ],
+          "id": "units"
+        }
+      ],
+      "sub_functions": [
+        {
+          "id": "actions",
+          "functions": [
+            {
+              "function_id": "Actor_ApplyBuff",
+              "is_enabled": true,
+              "parameters": [
+                {
+                  "expressions": [
+                    {
+                      "type": "Value",
+                      "value": {
+                        "type": {
+                          "directive": "TypeRef",
+                          "type": "Buff"
+                        },
+                        "value": "Uncontrollable_Buff"
+                      }
+                    }
+                  ],
+                  "id": "buff"
+                },
+                {
+                  "expressions": [
+                    {
+                      "type": "Value",
+                      "value": {
+                        "type": {
+                          "directive": "FunctionType",
+                          "type": "Integer"
+                        },
+                        "value": "1"
+                      }
+                    }
+                  ],
+                  "id": "stacks"
+                },
+                {
+                  "expressions": [
+                    {
+                      "type": "Function",
+                      "function": {
+                        "function_id": "UnitGroup_GetCurrentUnit",
+                        "is_enabled": true,
+                        "parameters": [],
+                        "sub_functions": []
+                      }
+                    }
+                  ],
+                  "id": "target"
+                },
+                {
+                  "expressions": [
+                    {
+                      "type": "Function",
+                      "function": {
+                        "function_id": "UnitGroup_GetCurrentUnit",
+                        "is_enabled": true,
+                        "parameters": [],
+                        "sub_functions": []
+                      }
+                    }
+                  ],
+                  "id": "source"
+                }
+              ],
+              "sub_functions": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "function_id": "Game_SetFogOfWar",
+      "parameters": [
+        {
+          "expressions": [
+            {
+              "function": {
+                "function_id": "PlayerGroup_GetPlayerAsPlayerGroup"
+              },
+              "type": "Function"
+            }
+          ],
+          "id": "player_group"
+        },
+        {
+          "id": "enabled",
+          "expressions": [
+            {
+              "type": "Preset",
+              "preset": {
+                "preset_id": "General_EnableDisable",
+                "value_id": "disable"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "based_on": "Trigger",
+  "conditions": [
+    {
+      "function_id": "Logic_Comparison",
+      "parameters": [
+        {
+          "expressions": [
+            {
+              "function": {
+                "function_id": "Player_GetTriggeringChatMessage"
+              },
+              "type": "Function"
+            }
+          ],
+          "id": "value1"
+        },
+        {
+          "expressions": [
+            {
+              "preset": {
+                "preset_id": "Logic_ComparisonOperator",
+                "value_id": "eq"
+              },
+              "type": "Preset"
+            }
+          ],
+          "id": "op"
+        },
+        {
+          "expressions": [
+            {
+              "type": "Value",
+              "value": {
+                "type": {
+                  "directive": "FunctionType",
+                  "type": "String"
+                },
+                "value": "!resign"
+              }
+            }
+          ],
+          "id": "value2"
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "function_id": "Player_OnPlayerSendsChatMessage",
+      "parameters": [
+        {
+          "expressions": [
+            {
+              "preset": {
+                "preset_id": "Player_AnyPlayer",
+                "value_id": "Any"
+              },
+              "type": "Preset"
+            }
+          ],
+          "id": "player"
+        }
+      ]
+    }
+  ],
+  "id": "ChatMessageResign"
+}


### PR DESCRIPTION
Players can now type `!resign` and the following will happen:
- The game will end for the player in defeat
  - If the player chooses "Continue Solo", they will remain in the game until the Game end condition is reached (victory for a team)
- Fog of war is disabled (the map is revealed)
- All units become uncontrollable

See: https://discord.com/channels/1101590942076653660/1389464041402925107/1397483724513345578